### PR TITLE
Remove colored status bar on flat player

### DIFF
--- a/app/src/main/java/com/kabouzeid/gramophone/ui/fragments/player/flat/FlatPlayerFragment.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/ui/fragments/player/flat/FlatPlayerFragment.java
@@ -60,8 +60,6 @@ public class FlatPlayerFragment extends AbsPlayerFragment implements PlayerAlbum
 
     private Unbinder unbinder;
 
-    @BindView(R.id.player_status_bar)
-    View playerStatusBar;
     @Nullable
     @BindView(R.id.toolbar_container)
     FrameLayout toolbarContainer;
@@ -453,10 +451,9 @@ public class FlatPlayerFragment extends AbsPlayerFragment implements PlayerAlbum
 
         public AnimatorSet createDefaultColorChangeAnimatorSet(int newColor) {
             Animator backgroundAnimator = ViewUtil.createBackgroundColorTransition(fragment.playbackControlsFragment.getView(), fragment.lastColor, newColor);
-            Animator statusBarAnimator = ViewUtil.createBackgroundColorTransition(fragment.playerStatusBar, fragment.lastColor, newColor);
 
             AnimatorSet animatorSet = new AnimatorSet();
-            animatorSet.playTogether(backgroundAnimator, statusBarAnimator);
+            animatorSet.playTogether(backgroundAnimator);
 
             if (!ATHUtil.isWindowBackgroundDark(fragment.getActivity())) {
                 int adjustedLastColor = ColorUtil.isColorLight(fragment.lastColor) ? ColorUtil.darkenColor(fragment.lastColor) : fragment.lastColor;

--- a/app/src/main/res/layout/fragment_flat_player.xml
+++ b/app/src/main/res/layout/fragment_flat_player.xml
@@ -22,7 +22,7 @@
             android:layout_width="match_parent"
             android:layout_height="match_parent">
 
-            <FrameLayout
+            <RelativeLayout
                 android:id="@+id/player_content"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content">
@@ -40,7 +40,14 @@
 
                 </com.kabouzeid.gramophone.views.WidthFitSquareLayout>
 
-            </FrameLayout>
+                <fragment
+                    android:id="@+id/playback_controls_fragment"
+                    class="com.kabouzeid.gramophone.ui.fragments.player.flat.FlatPlayerPlaybackControlsFragment"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_below="@id/album_cover_container" />
+
+            </RelativeLayout>
 
             <FrameLayout
                 android:id="@+id/toolbar_container"
@@ -62,13 +69,9 @@
             android:id="@+id/player_panel"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
+            android:layout_marginTop="@dimen/status_bar_padding"
             android:orientation="vertical">
 
-            <fragment
-                android:id="@+id/playback_controls_fragment"
-                class="com.kabouzeid.gramophone.ui.fragments.player.flat.FlatPlayerPlaybackControlsFragment"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content" />
 
             <RelativeLayout
                 android:layout_width="match_parent"

--- a/app/src/main/res/layout/fragment_flat_player.xml
+++ b/app/src/main/res/layout/fragment_flat_player.xml
@@ -4,21 +4,7 @@
     android:layout_height="match_parent"
     android:orientation="vertical">
 
-    <FrameLayout
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content">
 
-        <View
-            android:id="@+id/player_status_bar"
-            android:layout_width="match_parent"
-            android:layout_height="@dimen/status_bar_padding" />
-
-        <View
-            android:layout_width="match_parent"
-            android:layout_height="@dimen/status_bar_padding"
-            android:background="@color/twenty_percent_black_overlay" />
-
-    </FrameLayout>
 
     <com.sothree.slidinguppanel.SlidingUpPanelLayout
         xmlns:sothree="http://schemas.android.com/apk/res-auto"
@@ -65,6 +51,7 @@
                 <android.support.v7.widget.Toolbar
                     android:id="@+id/player_toolbar"
                     style="@style/Toolbar"
+                    android:layout_marginTop="@dimen/status_bar_padding"
                     android:background="@android:color/transparent" />
 
             </FrameLayout>


### PR DESCRIPTION
Removes the colored statusbar on the flat player.
Stop player controls being dragged to the top along with the playing queue. 